### PR TITLE
[ohayoMAYA] 動作検証用のサンプルデータを追加

### DIFF
--- a/resources/sample_motion/Maya/Maya.mb
+++ b/resources/sample_motion/Maya/Maya.mb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ee62073d6a8e1cc22ab5583df205129bcf9bf7ad3bc688ef439eaa5a6811c02
+size 3696572

--- a/resources/sample_motion/Maya/motion_data_from_Maya.fbx
+++ b/resources/sample_motion/Maya/motion_data_from_Maya.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cafe97f67431a9f74a8a8cabb053ebfd661e4ac0a67becf230a3d2810ad21da
+size 718096

--- a/resources/sample_motion/Maya/motion_data_from_XYN.fbx
+++ b/resources/sample_motion/Maya/motion_data_from_XYN.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4453e7ca2e393b75bd53164c407447319b1c2dc6f8e1d1f1a0ec3e0d17be5a65
+size 2123232

--- a/resources/sample_motion/XYN/XYN.mspj
+++ b/resources/sample_motion/XYN/XYN.mspj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fa406d211db391c41a33c707aad6328ac4c01800141cab3bc0767547ba8fdb8
+size 2436222

--- a/resources/sample_motion/XYN/capture_data_in_ZYN.bvh
+++ b/resources/sample_motion/XYN/capture_data_in_ZYN.bvh
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19e0cc2e466f4ee44dc9f22929ac9e7c08abcfb426d40b0b6de6100579d297d6
+size 4844269


### PR DESCRIPTION
## 概要
- GitLFSに対応できたので、モーションデータおよびMayaプロジェクトのサンプルを追加しました。

## 変更箇所
- XYN-MotionStudioのキャプチャデータ
- XYN-MotionStudioからエクスポートされたモーションデータ
- Mayaからエクスポートされたモーションデータ